### PR TITLE
fix: update gradle annotations to make plugins work

### DIFF
--- a/artemis-build-tools/artemis-gradle/src/main/java/com/artemis/ArtemisGradlePlugin.java
+++ b/artemis-build-tools/artemis-gradle/src/main/java/com/artemis/ArtemisGradlePlugin.java
@@ -6,11 +6,11 @@ import org.gradle.api.Plugin;
 /**
  * @author Daan van Yperen
  */
-public class ArtemisGradlePlugin  implements Plugin<Project> {
+public class ArtemisGradlePlugin implements Plugin<Project> {
 
-	@Override
-	public void apply(Project target) {
-		target.getTasks().create("weave", ArtemisWeavingTask.class);
-	}
+    @Override
+    public void apply(Project target) {
+        target.getTasks().create("weave", ArtemisWeavingTask.class).setGroup("artemis");
+    }
 
 }

--- a/artemis-build-tools/artemis-gradle/src/main/java/com/artemis/ArtemisWeavingTask.java
+++ b/artemis-build-tools/artemis-gradle/src/main/java/com/artemis/ArtemisWeavingTask.java
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 
 import java.io.File;
 
@@ -22,134 +23,128 @@ import java.io.File;
  */
 public class ArtemisWeavingTask extends DefaultTask {
 
-	/**
-	 * Root folder for class files.
-	 *
-	 * @deprecated use classesDirs
-	 */
-	@Optional
-	@Deprecated
-	@OutputDirectory
-	private File classesDir;
+    /**
+     * Root folder for class files.
+     *
+     * @deprecated use classesDirs
+     */
+    @Optional
+    @Deprecated
+    private File classesDir;
 
-	/**
-	 * Root directories for class files.
-	 */
-	@Optional
-	@OutputDirectories
-	private FileCollection classesDirs;
+    /**
+     * Root directories for class files.
+     */
+    @Optional
+    private FileCollection classesDirs;
 
-	/**
-	 * Enabled weaving of pooled components (more viable on Android than JVM).
-	 */
-	@Input
-	private boolean enablePooledWeaving;
+    private boolean enablePooledWeaving;
 
-	/**
-	 * If false, no weaving will take place (useful for debugging).
-	 */
-	@Input
-	private boolean enableArtemisPlugin;
+    private boolean enableArtemisPlugin;
 
-	@Input
-	private boolean optimizeEntitySystems;
+    private boolean optimizeEntitySystems;
 
-	/**
-	 * Generate optimized read/write classes for entity link fields, used
-	 * by the {@link com.artemis.link.EntityLinkManager}.
-	 */
-	@Input
-	private boolean generateLinkMutators;
+    private boolean generateLinkMutators;
 
-	@TaskAction
-	public void weave() {
-		getLogger().info("Artemis plugin started.");
+    @TaskAction
+    public void weave() {
+        getLogger().info("Artemis plugin started.");
 
-		if (!enableArtemisPlugin) {
-			getLogger().info("Plugin disabled via 'enableArtemisPlugin' set to false.");
-			return;
-		}
+        if (!enableArtemisPlugin) {
+            getLogger().info("Plugin disabled via 'enableArtemisPlugin' set to false.");
+            return;
+        }
 
-		long start = System.currentTimeMillis();
-		//@todo provide gradle alternative.
-		//if (context != null && !context.hasDelta(sourceDirectory)) return;
+        long start = System.currentTimeMillis();
+        //@todo provide gradle alternative.
+        //if (context != null && !context.hasDelta(sourceDirectory)) return;
 
-		Logger log = getLogger();
+        Logger log = getLogger();
 
 //		log.info("");
-		log.info("CONFIGURATION");
-		log.info(WeaverLog.LINE.replaceAll("\n", ""));
-		log.info(WeaverLog.format("enablePooledWeaving", enablePooledWeaving));
-		log.info(WeaverLog.format("generateLinkMutators", generateLinkMutators));
-		log.info(WeaverLog.format("optimizeEntitySystems", optimizeEntitySystems));
-		if (classesDirs != null && !classesDirs.isEmpty()) {
-			log.info(WeaverLog.format("outputDirectories", classesDirs.getFiles()));
-		} else {
-			log.info(WeaverLog.format("outputDirectory", classesDir));
-		}
-		log.info(WeaverLog.LINE.replaceAll("\n", ""));
-		
-		Weaver.enablePooledWeaving(enablePooledWeaving);
-		Weaver.generateLinkMutators(generateLinkMutators);
-		Weaver.optimizeEntitySystems(optimizeEntitySystems);
+        log.info("CONFIGURATION");
+        log.info(WeaverLog.LINE.replaceAll("\n", ""));
+        log.info(WeaverLog.format("enablePooledWeaving", enablePooledWeaving));
+        log.info(WeaverLog.format("generateLinkMutators", generateLinkMutators));
+        log.info(WeaverLog.format("optimizeEntitySystems", optimizeEntitySystems));
+        if (classesDirs != null && !classesDirs.isEmpty()) {
+            log.info(WeaverLog.format("outputDirectories", classesDirs.getFiles()));
+        } else {
+            log.info(WeaverLog.format("outputDirectory", classesDir));
+        }
+        log.info(WeaverLog.LINE.replaceAll("\n", ""));
 
-		Weaver weaver;
-		if (classesDirs != null && !classesDirs.isEmpty()) {
-			weaver = new Weaver(classesDirs.getFiles());
-		} else {
-			weaver = new Weaver(classesDir);
-		}
-		WeaverLog processed = weaver.execute();
-		for (String s : processed.getFormattedLog().split("\n")) {
-			log.info(s);
-		}
-	}
+        Weaver.enablePooledWeaving(enablePooledWeaving);
+        Weaver.generateLinkMutators(generateLinkMutators);
+        Weaver.optimizeEntitySystems(optimizeEntitySystems);
 
-	public boolean isEnableArtemisPlugin() {
-		return enableArtemisPlugin;
-	}
+        Weaver weaver;
+        if (classesDirs != null && !classesDirs.isEmpty()) {
+            weaver = new Weaver(classesDirs.getFiles());
+        } else {
+            weaver = new Weaver(classesDir);
+        }
+        WeaverLog processed = weaver.execute();
+        for (String s : processed.getFormattedLog().split("\n")) {
+            log.info(s);
+        }
+    }
 
-	public void setEnableArtemisPlugin(boolean enableArtemisPlugin) {
-		this.enableArtemisPlugin = enableArtemisPlugin;
-	}
+    @Input
+    public boolean isEnableArtemisPlugin() {
+        return enableArtemisPlugin;
+    }
 
-	public boolean isEnablePooledWeaving() {
-		return enablePooledWeaving;
-	}
+    @Input
+    public boolean isGenerateLinkMutators() {
+        return generateLinkMutators;
+    }
 
-	public void setEnablePooledWeaving(boolean enablePooledWeaving) {
-		this.enablePooledWeaving = enablePooledWeaving;
-	}
+    @Input
+    public boolean isEnablePooledWeaving() {
+        return enablePooledWeaving;
+    }
 
-	public void setGenerateLinkMutators(boolean generateLinkMutators) {
-		this.generateLinkMutators = generateLinkMutators;
-	}
+    @Input
+    public boolean isOptimizeEntitySystems() {
+        return optimizeEntitySystems;
+    }
 
-	public boolean isGenerateLinkMutators() {
-		return generateLinkMutators;
-	}
+    @Option(option = "enable-artemis-plugin", description = "If false, no weaving will take place (useful for debugging).")
+    public void setEnableArtemisPlugin(boolean enableArtemisPlugin) {
+        this.enableArtemisPlugin = enableArtemisPlugin;
+    }
 
-	public boolean isOptimizeEntitySystems() {
-		return optimizeEntitySystems;
-	}
+    @Option(option = "enable-pooled-weaving", description = "Enabled weaving of pooled components (more viable on Android than JVM).")
+    public void setEnablePooledWeaving(boolean enablePooledWeaving) {
+        this.enablePooledWeaving = enablePooledWeaving;
+    }
 
-	public void setOptimizeEntitySystems(boolean optimizeEntitySystems) {
-		this.optimizeEntitySystems = optimizeEntitySystems;
-	}
+    @Option(option = "generate-link-mutators", description = "Generate optimized read/write classes for entity link fields, used")
+    public void setGenerateLinkMutators(boolean generateLinkMutators) {
+        this.generateLinkMutators = generateLinkMutators;
+    }
 
-	public File getClassesDir() {
-		return classesDir;
-	}
+    @Option(option = "optimize-entity-systems", description = "Compile Optimized Systems")
+    public void setOptimizeEntitySystems(boolean optimizeEntitySystems) {
+        this.optimizeEntitySystems = optimizeEntitySystems;
+    }
 
-	public void setClassesDir(File classesDir) {
-		this.classesDir = classesDir;
-	}
+    @OutputDirectory
+    public File getClassesDir() {
+        return classesDir;
+    }
 
-	public FileCollection getClassesDirs() {
-		return classesDirs;
-	}
+    public void setClassesDir(File classesDir) {
+        this.classesDir = classesDir;
+    }
 
-	public void setClassesDirs(FileCollection classesDirs) {
-		this.classesDirs = classesDirs;
-	}
+    @OutputDirectories
+    public FileCollection getClassesDirs() {
+        return classesDirs;
+    }
+
+    public void setClassesDirs(FileCollection classesDirs) {
+        this.classesDirs = classesDirs;
+    }
 }

--- a/artemis-fluid/artemis-fluid-gradle-plugin/src/main/java/com/artemis/FluidApiGenerationTask.java
+++ b/artemis-fluid/artemis-fluid-gradle-plugin/src/main/java/com/artemis/FluidApiGenerationTask.java
@@ -1,17 +1,12 @@
 package com.artemis;
 
-import com.artemis.FluidGenerator;
-import com.artemis.FluidGeneratorPreferences;
-
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -27,13 +22,10 @@ import java.util.Set;
  */
 public class FluidApiGenerationTask extends DefaultTask {
 
-    @InputFile
     private File generatedSourcesDirectory;
 
-    @InputFiles
     private FileCollection classpath;
 
-    @Input
     public FluidGeneratorPreferences preferences = new FluidGeneratorPreferences();
 
     @TaskAction
@@ -97,22 +89,32 @@ public class FluidApiGenerationTask extends DefaultTask {
         }
     }
 
+    @Input
     public FluidGeneratorPreferences getPreferences() {
         return preferences;
     }
 
+    @Option(option = "preferences", description = "Configures the fluid generator preferences, you can filter classes to process using a regex (File).")
+    public void setPreferences(FluidGeneratorPreferences preferences) {
+        this.preferences = preferences;
+    }
+
+    @InputFile
     public File getGeneratedSourcesDirectory() {
         return generatedSourcesDirectory;
     }
 
+    @Option(option = "generated-sources-directory", description = "Configures the source of generated sources (File).")
     public void setGeneratedSourcesDirectory(File generatedSourcesDirectory) {
         this.generatedSourcesDirectory = generatedSourcesDirectory;
     }
 
+    @InputFiles
     public FileCollection getClasspath() {
         return classpath;
     }
 
+    @Option(option = "classpath", description = "Configures the classpath (FileCollection).")
     public void setClasspath(FileCollection classpath) {
         this.classpath = classpath;
     }

--- a/artemis-fluid/artemis-fluid-gradle-plugin/src/main/java/com/artemis/FluidArtemisGradlePlugin.java
+++ b/artemis-fluid/artemis-fluid-gradle-plugin/src/main/java/com/artemis/FluidArtemisGradlePlugin.java
@@ -10,7 +10,8 @@ public class FluidArtemisGradlePlugin implements Plugin<Project> {
 
 	@Override
 	public void apply(Project target) {
-		target.getTasks().create("fluid", FluidApiGenerationTask.class);
+		FluidApiGenerationTask fluidTask = target.getTasks().create("fluid", FluidApiGenerationTask.class);
+		fluidTask.setGroup("artemis");
 	}
 
 }


### PR DESCRIPTION
# Description

Adapting to Gradle API changes:
- `@Input` annotation on Java tasks should be used on methods
- `@Option` annotation on Java tasks can be used on methods indicating the name and description